### PR TITLE
fix: make all exports available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,5 @@
-export {
-  valueToZDBigNumber,
-  valueToBigNumber,
-  BigNumberValue,
-} from './helpers/bignumber';
+export * from './helpers/bignumber';
 export { BigNumber } from 'bignumber.js';
-export {
-  normalize,
-  calculateAvailableBorrowsETH,
-  calculateHealthFactorFromBalances,
-  calculateHealthFactorFromBalancesBigUnits,
-  getCompoundedBalance,
-  getCompoundedStableBalance,
-  calculateCompoundedInterest,
-  LTV_PRECISION,
-} from './helpers/pool-math';
-export {
-  ReserveData,
-  ComputedReserveData,
-  UserReserveData,
-  UserSummaryData,
-  ComputedUserReserve,
-} from './types';
-
-export {
-  formatReserves,
-  formatUserSummaryData,
-  computeRawUserSummaryData,
-} from './computations-and-formatting';
+export * from './helpers/pool-math';
+export * from './types';
+export * from './computations-and-formatting';


### PR DESCRIPTION
a faed multiple issues where a helper utility i wanted to use has only type definition, but no actual export.
For historic rate calculation i need access to the underlaying helpers