### PR TITLE
fix: timestamp is number not string

### DIFF
--- a/src/v2/types.ts
+++ b/src/v2/types.ts
@@ -28,7 +28,7 @@ export type ReserveData = {
   stableRateSlope1: string;
   stableRateSlope2: string;
   averageStableRate: string;
-  stableDebtLastUpdateTimestamp: string;
+  stableDebtLastUpdateTimestamp: number;
   baseVariableBorrowRate: string;
   variableRateSlope1: string;
   variableRateSlope2: string;


### PR DESCRIPTION
this causes quite some type frustration, when using codegen as you have to manually cast the types to not throw in utility functions