### PR TITLE
fix: allow wp shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lending",
     "defi"
   ],
+  "sideEffects": false,
   "author": "Aave <tech@aave.com>",
   "contributors": [
     {


### PR DESCRIPTION
Adding light-client had a immense penalty on build size using webpack & only needing subsets of the lib.

Without `@aave/protocol-js`:
`└ ○ /test                                                      268 B`

With Bignumber from `@aave/protocol-js` `import { BigNumber } from "@aave/protocol-js";`:
`└ ○ /test                                                      196 kB`

With this patch applied:
`└ ○ /test                                                      8.45 kB`

I think this should be safe as all functions are sideEffect free.