### PR TITLE
chore: add dependabot [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 40


### PR DESCRIPTION
dependabot was acquired by github a while and we're currently using the legacy version.
let's switch to the new one as it's doing semantic commit messages by default afaik

Also testing if skip ci works on a branch level