### PR TITLE
chore: improve ci

### DIFF
--- a/.github/workflows/prerelease-ci.yaml
+++ b/.github/workflows/prerelease-ci.yaml
@@ -1,7 +1,11 @@
-name: ci
+name: release-ci
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   release:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -36,12 +40,15 @@ jobs:
         name: prerelease
         if: github.ref != 'refs/heads/master'
         run: |
-          yarn release  --message "chore(release): Release v%s :tada: [ci skip]" --prerelease ${{ github.sha }}
-          yarn publish
+          yarn release --message "chore(release): Release v%s :tada: [ci skip]" --prerelease ${{ github.sha }}
+          yarn publish --tag canary
 
       - id: release
         name: release
-        if: github.ref == 'refs/heads/master'
+        if: |
+          contains(github.event.head_commit.message, 'chore(release)') &&
+          github.ref == 'refs/heads/master'
         run: |
-          yarn release --message "chore(release): Release v%s :tada: [ci skip]"
-          git push --follow-tags origin master && yarn publish
+          git tag v$(cat package.json | jq --raw-output '.version')
+          git push --follow-tags origin master
+          yarn publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,14 @@ which might potentially be breaking" # will result in a major x.0.0
 git commit -m "fix!: <function> types now reflect the actual output" # will result in a major x.0.0
 
 ```
+
+## Release process
+
+To propose a new release you have to create a branch, run `yarn release:prod` and create a pr for that branch.
+Once the branch is merged to master a npm release will be published automatically.
+
+```bash
+git checkout -b <branch>
+yarn release:prod
+git push origin <branch>
+```

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "lint": "tsdx lint",
     "prepare": "npm run build",
     "compile": "SKIP_LOAD=true hardhat compile",
-    "release": "standard-version"
+    "release": "standard-version",
+    "release:prod": "yarn release --message \"chore(release): Release v%s :tada:\" --skip.tag"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^4.0.0",


### PR DESCRIPTION
I spend some time reading up on how people do this with github actions and it's honestly messy:
a) disable branch protection
b) take an admins access token
c) create a so called bot/service¹ account which is roughly the same as b)
d) do the production release manually

> ¹https://docs.github.com/en/github/getting-started-with-github/types-of-github-accounts#personal-user-accounts
> User accounts are intended for humans, but you can give one to a robot, such as a continuous integration bot, if necessary.

a) would rely on "trusting collaborators not to push on master", without enforcing it
... b) c) seem weird to me and doesn't work well with protected branches as you would still have to force push

---

if we go more in direction of github with other repos it might make sense to setup b) or c), but for now it seemed overkill so i went with d) in this pr.

The ci now works like this:
- branches created by collaborators will create a npm release with `@canary` tag `yarn i @aave/protocol-js@canary`
- `chore(release):` commits on master will create a tag and a npm release as `@latest` (the default with `npm i`)

^ to create a release follow [this guide](https://github.com/aave/aave-js/pull/43/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R29)