### PR TITLE
test: release

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -3,7 +3,7 @@ name: release-ci
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [2.3.1](https://github.com/aave/aave-js/compare/v2.3.0...v2.3.1) (2021-01-26)
+
+
+### Bug Fixes
+
+* actually run ci release on master ([#39](https://github.com/aave/aave-js/issues/39)) ([850f386](https://github.com/aave/aave-js/commit/850f3862a63094fe6556b37a077af881942a6e3a))
+* allow wp shaking ([bc54e8a](https://github.com/aave/aave-js/commit/bc54e8a164d8118ca308a70a4dad8212263f1a0e))
+* another try fixing ci :sob: ([#41](https://github.com/aave/aave-js/issues/41)) ([7d4121c](https://github.com/aave/aave-js/commit/7d4121c891f32bbbca288eda409d6e737c39b5e5))
+* fix some other readme referenes ([83c2d73](https://github.com/aave/aave-js/commit/83c2d73818e349c7ee7438995c7bad0da430fda1))
+* moved contract initialization inside conditional ([#40](https://github.com/aave/aave-js/issues/40)) ([a75ee67](https://github.com/aave/aave-js/commit/a75ee671aa20d659da8d3e52b9445f428ee6486e))
+* update readme ([15f2faf](https://github.com/aave/aave-js/commit/15f2faf821b54343694e9466331222a0c62b7bef))

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "name": "@aave/protocol-js",
   "description": "Aave protocol data aggregation tool",


### PR DESCRIPTION
it's a test of #43  - i just ran `yarn release:prod` on a new branch which generated https://github.com/aave/aave-js/commit/7e22c625bef7a5a80c89303fe14e55e34388d23a