### PR TITLE
perf: store 10 pows in mem for subsequent lookups

### DIFF
--- a/benchmarks/normalize.js
+++ b/benchmarks/normalize.js
@@ -1,0 +1,53 @@
+const { valueToZDBigNumber, normalize, BigNumber } = require('../dist');
+const Benchmark = require('benchmark');
+
+Benchmark.options.minSamples = 200;
+const PRECISION = 2;
+const results = [];
+const suite = new Benchmark.Suite();
+
+const value = valueToZDBigNumber('323788616402133497883602337');
+
+function legacyNormalize(n, decimals) {
+  return new BigNumber(n)
+    .dividedBy(new BigNumber('10').pow(decimals))
+    .toString(10);
+}
+
+suite
+  // add tests
+  .add('legacyNormalize', () => {
+    legacyNormalize(value, Math.floor(Math.random() * 24));
+  })
+  .add('normalizeWithMemoization', () => {
+    normalize(value, Math.floor(Math.random() * 24));
+  })
+
+  // add listeners
+  .on('cycle', event =>
+    results.push({
+      name: event.target.name,
+      hz: event.target.hz,
+      'margin of error': `±${Number(event.target.stats.rme).toFixed(2)}%`,
+      'runs sampled': event.target.stats.sample.length,
+    })
+  )
+  .on('complete', function() {
+    const lowestHz = results.slice().sort((a, b) => a.hz - b.hz)[0].hz;
+
+    console.table(
+      results
+        .sort((a, b) => b.hz - a.hz)
+        .map(result => ({
+          ...result,
+          hz: Math.round(result.hz).toLocaleString(),
+          numTimesFaster:
+            Math.round((10 ** PRECISION * result.hz) / lowestHz) /
+            10 ** PRECISION,
+        }))
+        .reduce((acc, { name, ...cur }) => ({ ...acc, [name]: cur }), {})
+    );
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+
+  .run({ async: false });

--- a/src/helpers/bignumber.ts
+++ b/src/helpers/bignumber.ts
@@ -19,7 +19,7 @@ const bn10 = new BigNumber(10);
 
 const bn10PowLookup: { [key: number]: BigNumberValue } = {};
 
-function pow10(decimals: number) {
+export function pow10(decimals: number) {
   if (!bn10PowLookup[decimals]) bn10PowLookup[decimals] = bn10.pow(decimals);
   return bn10PowLookup[decimals];
 }

--- a/src/helpers/bignumber.ts
+++ b/src/helpers/bignumber.ts
@@ -10,6 +10,20 @@ export const BigNumberZD = BigNumber.clone({
 export function valueToBigNumber(amount: BigNumberValue): BigNumber {
   return new BigNumber(amount);
 }
+
 export function valueToZDBigNumber(amount: BigNumberValue): BigNumber {
   return new BigNumberZD(amount);
+}
+
+const bn10 = new BigNumber(10);
+
+const bn10PowLookup: { [key: number]: BigNumberValue } = {};
+
+function pow10(decimals: number) {
+  if (!bn10PowLookup[decimals]) bn10PowLookup[decimals] = bn10.pow(decimals);
+  return bn10PowLookup[decimals];
+}
+
+export function normalize(n: BigNumberValue, decimals: number): string {
+  return new BigNumber(n).dividedBy(pow10(decimals)).toString(10);
 }

--- a/src/helpers/bignumber.ts
+++ b/src/helpers/bignumber.ts
@@ -17,18 +17,20 @@ export function valueToZDBigNumber(amount: BigNumberValue): BigNumber {
 
 const bn10 = new BigNumber(10);
 
-const bn10PowLookup: { [key: number]: BigNumberValue } = {};
+const bn10PowLookup: { [key: number]: BigNumber } = {};
 
 /**
  * It's a performance optimized version of 10 ** x, which essentially memoizes previously used pows and resolves them as lookup.
  * @param decimals
  * @returns 10 ** decimals
  */
-export function pow10(decimals: number) {
+export function pow10(decimals: number): BigNumber {
   if (!bn10PowLookup[decimals]) bn10PowLookup[decimals] = bn10.pow(decimals);
   return bn10PowLookup[decimals];
 }
 
 export function normalize(n: BigNumberValue, decimals: number): string {
-  return new BigNumber(n).dividedBy(pow10(decimals)).toString(10);
+  return valueToBigNumber(n)
+    .dividedBy(pow10(decimals))
+    .toString(10);
 }

--- a/src/helpers/bignumber.ts
+++ b/src/helpers/bignumber.ts
@@ -19,6 +19,11 @@ const bn10 = new BigNumber(10);
 
 const bn10PowLookup: { [key: number]: BigNumberValue } = {};
 
+/**
+ * It's a performance optimized version of 10 ** x, which essentially memoizes previously used pows and resolves them as lookup.
+ * @param decimals
+ * @returns 10 ** decimals
+ */
 export function pow10(decimals: number) {
   if (!bn10PowLookup[decimals]) bn10PowLookup[decimals] = bn10.pow(decimals);
   return bn10PowLookup[decimals];

--- a/src/helpers/pool-math.ts
+++ b/src/helpers/pool-math.ts
@@ -10,12 +10,6 @@ import { SECONDS_PER_YEAR } from './constants';
 
 export const LTV_PRECISION = 4;
 
-export function normalize(n: BigNumberValue, decimals: number): string {
-  return new BigNumber(n)
-    .dividedBy(new BigNumber('10').pow(decimals))
-    .toString(10);
-}
-
 export function calculateCompoundedInterest(
   rate: BigNumberValue,
   currentTimestamp: BigNumberValue,

--- a/src/helpers/pool-math.ts
+++ b/src/helpers/pool-math.ts
@@ -4,6 +4,7 @@ import {
   BigNumberValue,
   valueToBigNumber,
   valueToZDBigNumber,
+  pow10,
 } from './bignumber';
 import * as RayMath from './ray-math';
 import { SECONDS_PER_YEAR } from './constants';
@@ -80,7 +81,7 @@ export function calculateHealthFactorFromBalances(
   }
   return valueToBigNumber(collateralBalanceETH)
     .multipliedBy(currentLiquidationThreshold)
-    .dividedBy(10 ** LTV_PRECISION)
+    .dividedBy(pow10(LTV_PRECISION))
     .div(borrowBalanceETH);
 }
 
@@ -93,7 +94,7 @@ export function calculateHealthFactorFromBalancesBigUnits(
     collateralBalanceETH,
     borrowBalanceETH,
     new BigNumber(currentLiquidationThreshold)
-      .multipliedBy(10 ** LTV_PRECISION)
+      .multipliedBy(pow10(LTV_PRECISION))
       .decimalPlaces(0, BigNumber.ROUND_DOWN)
   );
 }
@@ -108,7 +109,7 @@ export function calculateAvailableBorrowsETH(
   }
   const availableBorrowsETH = valueToZDBigNumber(collateralBalanceETH)
     .multipliedBy(currentLtv)
-    .dividedBy(10 ** LTV_PRECISION)
+    .dividedBy(pow10(LTV_PRECISION))
     .minus(borrowBalanceETH);
   return availableBorrowsETH.gt('0')
     ? availableBorrowsETH

--- a/src/test/ray-math.test.ts
+++ b/src/test/ray-math.test.ts
@@ -1,6 +1,10 @@
 import BigNumber from 'bignumber.js';
 import { SECONDS_PER_YEAR } from '../helpers/constants';
-import { BigNumberValue, valueToZDBigNumber } from '../helpers/bignumber';
+import {
+  BigNumberValue,
+  valueToZDBigNumber,
+  normalize,
+} from '../helpers/bignumber';
 import {
   RAY,
   rayMul,
@@ -8,7 +12,7 @@ import {
   binomialApproximatedRayPow,
   rayDiv,
 } from '../helpers/ray-math';
-import { calculateCompoundedInterest, normalize } from '../helpers/pool-math';
+import { calculateCompoundedInterest } from '../helpers/pool-math';
 
 describe('wadMul should', () => {
   it('work correctly', () => {

--- a/src/v1/computations-and-formatting.ts
+++ b/src/v1/computations-and-formatting.ts
@@ -12,8 +12,8 @@ import {
   BigNumberValue,
   valueToBigNumber,
   valueToZDBigNumber,
+  normalize,
 } from '../helpers/bignumber';
-import { normalize } from '../helpers/pool-math';
 import {
   ETH_DECIMALS,
   RAY_DECIMALS,

--- a/src/v1/computations-and-formatting.ts
+++ b/src/v1/computations-and-formatting.ts
@@ -13,6 +13,7 @@ import {
   valueToBigNumber,
   valueToZDBigNumber,
   normalize,
+  pow10,
 } from '../helpers/bignumber';
 import {
   ETH_DECIMALS,
@@ -254,17 +255,17 @@ function computeUserReserveData(
   );
   const currentUnderlyingBalanceETH = currentUnderlyingBalance
     .multipliedBy(priceInEth)
-    .dividedBy(10 ** decimals);
+    .dividedBy(pow10(decimals));
   const currentUnderlyingBalanceUSD = currentUnderlyingBalanceETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toFixed(0);
 
   const principalBorrowsETH = valueToZDBigNumber(userReserve.principalBorrows)
     .multipliedBy(priceInEth)
-    .dividedBy(10 ** decimals);
+    .dividedBy(pow10(decimals));
   const principalBorrowsUSD = principalBorrowsETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toFixed(0);
 
@@ -275,17 +276,17 @@ function computeUserReserveData(
   );
   const currentBorrowsETH = currentBorrows
     .multipliedBy(priceInEth)
-    .dividedBy(10 ** decimals);
+    .dividedBy(pow10(decimals));
   const currentBorrowsUSD = currentBorrowsETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toFixed(0);
 
   const originationFeeETH = valueToZDBigNumber(userReserve.originationFee)
     .multipliedBy(priceInEth)
-    .dividedBy(10 ** decimals);
+    .dividedBy(pow10(decimals));
   const originationFeeUSD = originationFeeETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toFixed(0);
 
@@ -390,22 +391,22 @@ export function computeRawUserSummaryData(
   );
 
   const totalCollateralUSD = totalCollateralETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
   const totalLiquidityUSD = totalLiquidityETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
   const totalBorrowsUSD = totalBorrowsETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
   const totalFeesUSD = totalFeesETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth);
 
   const totalBorrowsWithFeesETH = totalFeesETH.plus(totalBorrowsETH);

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -5,6 +5,7 @@ import {
   valueToBigNumber,
   valueToZDBigNumber,
   normalize,
+  pow10,
 } from '../helpers/bignumber';
 import {
   calculateAvailableBorrowsETH,
@@ -34,9 +35,9 @@ export function getEthAndUsdBalance(
 ): [string, string] {
   const balanceInEth = valueToZDBigNumber(balance)
     .multipliedBy(priceInEth)
-    .dividedBy(10 ** decimals);
+    .dividedBy(pow10(decimals));
   const balanceInUsd = balanceInEth
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toFixed(0);
   return [balanceInEth.toString(), balanceInUsd];
@@ -223,17 +224,17 @@ export function computeRawUserSummaryData(
   );
 
   const totalCollateralUSD = totalCollateralETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
   const totalLiquidityUSD = totalLiquidityETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
   const totalBorrowsUSD = totalBorrowsETH
-    .multipliedBy(10 ** USD_DECIMALS)
+    .multipliedBy(pow10(USD_DECIMALS))
     .dividedBy(usdPriceEth)
     .toString();
 
@@ -282,7 +283,7 @@ export function formatUserSummaryData(
           ...reserve,
           reserveLiquidationBonus: normalize(
             valueToBigNumber(reserve.reserveLiquidationBonus).minus(
-              10 ** LTV_PRECISION
+              pow10(LTV_PRECISION)
             ),
             4
           ),

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -4,13 +4,13 @@ import {
   BigNumberValue,
   valueToBigNumber,
   valueToZDBigNumber,
+  normalize,
 } from '../helpers/bignumber';
 import {
   calculateAvailableBorrowsETH,
   calculateHealthFactorFromBalances,
   getCompoundedBalance,
   getCompoundedStableBalance,
-  normalize,
   calculateAverageRate,
   LTV_PRECISION,
   calculateCompoundedInterest,


### PR DESCRIPTION
It's speeding up normalize by more than 50% which is quite sth as it's the most used method we got here.

```
➜  aave-js git:(perf/mem-pow) ✗ node benchmarks/normalize.js
┌──────────────────────────┬───────────┬─────────────────┬──────────────┬────────────────┐
│         (index)          │    hz     │ margin of error │ runs sampled │ numTimesFaster │
├──────────────────────────┼───────────┼─────────────────┼──────────────┼────────────────┤
│ normalizeWithMemoization │ '286,278' │    '±2.76%'     │     275      │      1.72      │
│     legacyNormalize      │ '166,135' │    '±1.20%'     │     285      │       1        │
└──────────────────────────┴───────────┴─────────────────┴──────────────┴────────────────┘
Fastest is normalizeWithMemoization
➜  aave-js git:(perf/mem-pow) ✗ node benchmarks/normalize.js
┌──────────────────────────┬───────────┬─────────────────┬──────────────┬────────────────┐
│         (index)          │    hz     │ margin of error │ runs sampled │ numTimesFaster │
├──────────────────────────┼───────────┼─────────────────┼──────────────┼────────────────┤
│ normalizeWithMemoization │ '227,759' │    '±4.69%'     │     277      │      1.57      │
│     legacyNormalize      │ '144,909' │    '±2.87%'     │     276      │       1        │
└──────────────────────────┴───────────┴─────────────────┴──────────────┴────────────────┘
Fastest is normalizeWithMemoization
➜  aave-js git:(perf/mem-pow) ✗ node benchmarks/normalize.js
┌──────────────────────────┬───────────┬─────────────────┬──────────────┬────────────────┐
│         (index)          │    hz     │ margin of error │ runs sampled │ numTimesFaster │
├──────────────────────────┼───────────┼─────────────────┼──────────────┼────────────────┤
│ normalizeWithMemoization │ '309,412' │    '±1.24%'     │     287      │      1.74      │
│     legacyNormalize      │ '177,592' │    '±1.03%'     │     287      │       1        │
└──────────────────────────┴───────────┴─────────────────┴──────────────┴────────────────┘
Fastest is normalizeWithMemoization
➜  aave-js git:(perf/mem-pow) ✗ node benchmarks/normalize.js
┌──────────────────────────┬───────────┬─────────────────┬──────────────┬────────────────┐
│         (index)          │    hz     │ margin of error │ runs sampled │ numTimesFaster │
├──────────────────────────┼───────────┼─────────────────┼──────────────┼────────────────┤
│ normalizeWithMemoization │ '285,506' │    '±1.65%'     │     281      │      1.72      │
│     legacyNormalize      │ '165,824' │    '±2.68%'     │     274      │       1        │
└──────────────────────────┴───────────┴─────────────────┴──────────────┴────────────────┘
```