### PR TITLE
test: add test for getCompoundedStableBalance

### DIFF
--- a/src/test/pool-math.test.ts
+++ b/src/test/pool-math.test.ts
@@ -1,0 +1,22 @@
+import { getCompoundedStableBalance } from '../helpers/pool-math';
+
+describe('pool-math', () => {
+  describe('getCompoundedStableBalance', () => {
+    const daiDebt = {
+      userId: '0x117611135c32649b0fb4893d781ffc8fb99a73eb',
+      totalPrincipalStableDebt: '3517543407591028771061',
+      stableBorrowRate: '119976606800654227278644138',
+      decimals: 18,
+      stableDebtLastUpdateTimestamp: 1613857745,
+      symbol: 'DAI',
+    };
+    const ts = 1614248821;
+    const balance = getCompoundedStableBalance(
+      daiDebt.totalPrincipalStableDebt,
+      daiDebt.stableBorrowRate,
+      daiDebt.stableDebtLastUpdateTimestamp,
+      ts
+    );
+    expect(balance.toString()).toBe('3.522780300627623423259');
+  });
+});


### PR DESCRIPTION
On discord someone reported that stable debt via aave-js is not accurate.
We're talking about this level of accuracy though:
```
    Expected: "3.522780300627623423259"
    Received: "3.522780783106224263521e+21"
```
I created  a test to see if it's related to our rayPow approximation, but it seems to be not related. Creating this pr so that in case we can pick it up if we want to.