### PR TITLE
Fix underlyingBalance computing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "prettier/@typescript-eslint",
-    "plugin:prettier/recommended"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,17 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
+  "eslint": {
+    "parser": "@typescript-eslint/parser",
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:import/errors",
+      "plugin:import/warnings",
+      "plugin:import/typescript",
+      "plugin:prettier/recommended"
+    ]
+  },
   "resolutions": {
     "**/typescript": "^4.0.5",
     "**/@typescript-eslint/eslint-plugin": "^4.6.1",

--- a/src/test/v2/computation-and-formatting.test.ts
+++ b/src/test/v2/computation-and-formatting.test.ts
@@ -4,6 +4,7 @@ import {
   formatUserSummaryData,
 } from '../../v2/computations-and-formatting';
 import BigNumber from 'bignumber.js';
+import { getCompoundedBalance } from '../../helpers/pool-math';
 
 const mockReserve: ReserveData = {
   underlyingAsset: '0xff795577d9ac8bd7d90ee22b6c1703490b6512fd',
@@ -150,6 +151,28 @@ describe('computations and formattings', () => {
       )[0];
 
       expect(new BigNumber(second.totalDebt).gte(first.totalDebt)).toBe(true);
+    });
+
+    it('should compute collateral balance from blockchain data', () => {
+      // data exported from user 0xa5a69107816c5e3dfa5561e6b621dfe6294f6e5b
+      // at block number: 11581421
+      // reserve: YFI
+      const scaledATokenBalance = '161316503206059870';
+      const liquidityIndex = '1001723339432542553527150680';
+      const currentLiquidityRate = '22461916953455574582370088';
+      const lastUpdateTimestamp = 1609673617;
+      // at a later time, but on the same block
+      // expected balance computed with hardhat
+      const currentTimestamp = 1609675535;
+      const expectedATokenBalance = '161594727054623229';
+      const underlyingBalance = getCompoundedBalance(
+        scaledATokenBalance,
+        liquidityIndex,
+        currentLiquidityRate,
+        lastUpdateTimestamp,
+        currentTimestamp
+      ).toString();
+      expect(underlyingBalance).toBe(expectedATokenBalance);
     });
   });
 });

--- a/src/v1/computations-and-formatting.ts
+++ b/src/v1/computations-and-formatting.ts
@@ -47,7 +47,7 @@ export function getCompoundedBorrowBalance(
 
   let cumulatedInterest;
   if (userReserve.borrowRateMode === BorrowRateMode.Variable) {
-    let compoundedInterest = calculateCompoundedInterest(
+    const compoundedInterest = calculateCompoundedInterest(
       reserve.variableBorrowRate,
       currentTimestamp,
       reserve.lastUpdateTimestamp

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -2,28 +2,29 @@ import BigNumber from 'bignumber.js';
 
 import {
   BigNumberValue,
-  valueToBigNumber,
-  valueToZDBigNumber,
   normalize,
   pow10,
+  valueToBigNumber,
+  valueToZDBigNumber,
 } from '../helpers/bignumber';
 import {
   calculateAvailableBorrowsETH,
+  calculateAverageRate,
+  calculateCompoundedInterest,
   calculateHealthFactorFromBalances,
+  currentATokenBalance,
   getCompoundedBalance,
   getCompoundedStableBalance,
-  calculateAverageRate,
   LTV_PRECISION,
-  calculateCompoundedInterest,
 } from '../helpers/pool-math';
 import { rayMul } from '../helpers/ray-math';
 import {
+  ComputedReserveData,
   ComputedUserReserve,
   ReserveData,
+  ReserveRatesData,
   UserReserveData,
   UserSummaryData,
-  ReserveRatesData,
-  ComputedReserveData,
 } from './types';
 import { ETH_DECIMALS, RAY_DECIMALS, USD_DECIMALS } from '../helpers/constants';
 
@@ -75,7 +76,7 @@ export function computeUserReserveData(
     price: { priceInEth },
     decimals,
   } = poolReserve;
-  const underlyingBalance = getCompoundedBalance(
+  const underlyingBalance = currentATokenBalance(
     userReserve.scaledATokenBalance,
     poolReserve.liquidityIndex,
     poolReserve.liquidityRate,


### PR DESCRIPTION
Hi!

First of all, thank you for the dedication your putting on this project, the new protocol is awesome and well documented, it's a pleasure to work with.

I'm using `aave-js` and more specifically the `pool-math` helper to approximate users reserves balances from data previously fetched from the blockchain.

I found the library very useful to compute current `stableBorrows` with the `getCompoundedStableBalance` method, and current `variableBorrows` with the `getCompoundedBalance` method.

However I couldn't verify in my tests that the `getCompoundedBalance` method could be used to reliably compute the current `underlyingBalance`. With this in mind I tried to debug the method and to find a fix.

## Test case

First of all I added a (failing) test case to try to verify the claim I'm bringing forward. You can checkout to the "add failing test case" commit to run it: https://github.com/aave/aave-js/commit/cd01845ff2eed74ad56afb6f2f78cfb3ab337894

## Fix

After that I basically translated to Javascript the logic found in the protocol:

- method `calculateLinearInterest` of [MathUtils](https://github.com/aave/protocol-v2/blob/dbd77ad9312f607b420da746c2cb7385d734b015/contracts/protocol/libraries/math/MathUtils.sol#L21)
- method `getNormalizedIncome` of [ReserveLogic](https://github.com/aave/protocol-v2/blob/dbd77ad9312f607b420da746c2cb7385d734b015/contracts/protocol/libraries/logic/ReserveLogic.sol#L57)

; to create a new function `currentATokenBalance` specifically to compute the `underlyingBalance`.

You can find the new code in the commit "fix compute underlyingBalance": https://github.com/aave/aave-js/commit/3e2edb6d2d85266471a170793d1581d120cbd0c5.

Please give me your opinion on this, I may have overlooked something. Tell me what you think :)

## Misc
I had to fix the `eslint` config to be able to commit because, as you can see [here in the CI](https://github.com/aave/aave-js/runs/2011835755#step:5:38) the command `yarn lint` is broken.

The issue comes from the fact that `prettier/@typescript-eslint` is still used in the project while it has been deprecated (see [here](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21)).

However, I could not make it work by just modifying the `.eslintrc.json`, I think it is due to this issue: https://github.com/formium/tsdx/issues/498#issuecomment-583244717. `tsdx` doesn't seem to take into account the `extends` part of the `.eslintrc.json` config file. I had to migrate the config to the `package.json` file. It works for me now!