### PR TITLE
fix: move linear calculation from v1 to common

### DIFF
--- a/src/test/pool-math.test.ts
+++ b/src/test/pool-math.test.ts
@@ -1,0 +1,25 @@
+import { getLinearBalance } from '../helpers/pool-math';
+
+describe('pool math', () => {
+  it('should compute collateral balance from blockchain data', () => {
+    // data exported from user 0xa5a69107816c5e3dfa5561e6b621dfe6294f6e5b
+    // at block number: 11581421
+    // reserve: YFI
+    const scaledATokenBalance = '161316503206059870';
+    const liquidityIndex = '1001723339432542553527150680';
+    const currentLiquidityRate = '22461916953455574582370088';
+    const lastUpdateTimestamp = 1609673617;
+    // at a later time, but on the same block
+    // expected balance computed with hardhat
+    const currentTimestamp = 1609675535;
+    const expectedATokenBalance = '161594727054623229';
+    const underlyingBalance = getLinearBalance(
+      scaledATokenBalance,
+      liquidityIndex,
+      currentLiquidityRate,
+      lastUpdateTimestamp,
+      currentTimestamp
+    ).toString();
+    expect(underlyingBalance).toBe(expectedATokenBalance);
+  });
+});

--- a/src/v1/computations-and-formatting.ts
+++ b/src/v1/computations-and-formatting.ts
@@ -21,6 +21,10 @@ import {
   SECONDS_PER_YEAR,
   USD_DECIMALS,
 } from '../helpers/constants';
+import {
+  calculateAverageRate,
+  getReserveNormalizedIncome,
+} from '../helpers/pool-math';
 
 export type GetCompoundedBorrowBalanceParamsReserve = Pick<
   ReserveData,
@@ -81,21 +85,6 @@ export const calculateCompoundedInterest = (
   return RayMath.binomialApproximatedRayPow(ratePerSecond, timeDelta);
 };
 
-export const calculateLinearInterest = (
-  rate: BigNumberValue,
-  currentTimestamp: number,
-  lastUpdateTimestamp: number
-) => {
-  const timeDelta = RayMath.wadToRay(
-    valueToZDBigNumber(currentTimestamp - lastUpdateTimestamp)
-  );
-  const timeDeltaInSeconds = RayMath.rayDiv(
-    timeDelta,
-    RayMath.wadToRay(SECONDS_PER_YEAR)
-  );
-  return RayMath.rayMul(rate, timeDeltaInSeconds).plus(RayMath.RAY);
-};
-
 export function calculateHealthFactorFromBalances(
   collateralBalanceETH: BigNumberValue,
   borrowBalanceETH: BigNumberValue,
@@ -149,30 +138,11 @@ export function calculateAvailableBorrowsETH(
   return availableBorrowsETH.minus(borrowFee);
 }
 
-export type GetReserveNormalizedIncomeReserve = Pick<
-  ReserveData,
-  'liquidityRate' | 'liquidityIndex' | 'lastUpdateTimestamp'
->;
-
-export function getReserveNormalizedIncome(
-  reserve: GetReserveNormalizedIncomeReserve,
-  currentTimestamp: number
-): BigNumber {
-  const { liquidityRate, liquidityIndex, lastUpdateTimestamp } = reserve;
-  if (valueToZDBigNumber(liquidityRate).eq('0')) {
-    return valueToZDBigNumber(liquidityIndex);
-  }
-
-  const cumulatedInterest = calculateLinearInterest(
-    liquidityRate,
-    currentTimestamp,
-    lastUpdateTimestamp
-  );
-
-  return RayMath.rayMul(cumulatedInterest, liquidityIndex);
-}
-
-export type CalculateCumulatedBalancePoolReserve = GetReserveNormalizedIncomeReserve;
+export type CalculateCumulatedBalancePoolReserve = {
+  liquidityRate: BigNumberValue;
+  liquidityIndex: BigNumberValue;
+  lastUpdateTimestamp: number;
+};
 export type CalculateCumulatedBalanceUserReserve = Pick<
   UserReserveData,
   'userBalanceIndex'
@@ -566,20 +536,6 @@ export function formatUserSummaryData(
     ),
     healthFactor: userData.healthFactor,
   };
-}
-
-export function calculateAverageRate(
-  index0: string,
-  index1: string,
-  timestamp0: number,
-  timestamp1: number
-): string {
-  return new BigNumber(index1)
-    .dividedBy(index0)
-    .minus('1')
-    .dividedBy(timestamp1 - timestamp0)
-    .multipliedBy('31536000')
-    .toString();
 }
 
 export function formatReserves(

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -15,6 +15,7 @@ import {
   calculateAverageRate,
   LTV_PRECISION,
   calculateCompoundedInterest,
+  getLinearBalance,
 } from '../helpers/pool-math';
 import { rayMul } from '../helpers/ray-math';
 import {
@@ -75,7 +76,7 @@ export function computeUserReserveData(
     price: { priceInEth },
     decimals,
   } = poolReserve;
-  const underlyingBalance = getCompoundedBalance(
+  const underlyingBalance = getLinearBalance(
     userReserve.scaledATokenBalance,
     poolReserve.liquidityIndex,
     poolReserve.liquidityRate,


### PR DESCRIPTION
supersedes the liquidity part of #114, @alexandre-abrioux please have a look if this makes sense to you.

@kyzia551, please have a look as well - should we flag this breaking / should i add reexports to `v1.` to make this non breaking?
