### PR TITLE
fix: eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "prettier/@typescript-eslint",
-    "plugin:prettier/recommended"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,17 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
+  "eslint": {
+    "parser": "@typescript-eslint/parser",
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:import/errors",
+      "plugin:import/warnings",
+      "plugin:import/typescript",
+      "plugin:prettier/recommended"
+    ]
+  },
   "resolutions": {
     "**/typescript": "^4.0.5",
     "**/@typescript-eslint/eslint-plugin": "^4.6.1",

--- a/src/v1/computations-and-formatting.ts
+++ b/src/v1/computations-and-formatting.ts
@@ -47,7 +47,7 @@ export function getCompoundedBorrowBalance(
 
   let cumulatedInterest;
   if (userReserve.borrowRateMode === BorrowRateMode.Variable) {
-    let compoundedInterest = calculateCompoundedInterest(
+    const compoundedInterest = calculateCompoundedInterest(
       reserve.variableBorrowRate,
       currentTimestamp,
       reserve.lastUpdateTimestamp


### PR DESCRIPTION
cherry-picked from https://github.com/aave/aave-js/pull/114

> I had to fix the `eslint` config to be able to commit because, as you can see [here in the CI](https://github.com/aave/aave-js/runs/2011835755#step:5:38) the command `yarn lint` is broken.
>
> The issue comes from the fact that `prettier/@typescript-eslint` is still used in the project while it has been deprecated (see [here](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21)).
> 
> However, I could not make it work by just modifying the `.eslintrc.json`, I think it is due to this issue: https://github.com/formium/tsdx/issues/498#issuecomment-583244717. `tsdx` doesn't seem to take into account the `extends` part of the `.eslintrc.json` config file. I had to migrate the config to the `package.json` file. It works for me now!

as suggested by @sakulstra in https://github.com/aave/aave-js/pull/114#issuecomment-792783698

> would you mind reopening a pr, cherry picking the lint changes?