### PR TITLE
RFC: less strict types & flattened props

### DIFF
--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -405,9 +405,7 @@ export function formatReserves<
     lastUpdateTimestamp: number;
     liquidityIndex: string;
     liquidityRate: string;
-    price: {
-      priceInEth: string;
-    };
+    priceInEth: string;
     reserveFactor: string;
     reserveLiquidationBonus: string;
     reserveLiquidationThreshold: string;
@@ -417,21 +415,9 @@ export function formatReserves<
     totalPrincipalStableDebt: string;
     variableBorrowIndex: string;
     variableBorrowRate: string;
-  },
-  V extends {
-    id: string;
-    paramsHistory: {
-      variableBorrowIndex: string;
-      liquidityIndex: string;
-      timestamp: number;
-    }[];
   }
->(reserves: T[], currentTimestamp?: number, reserveIndexes30DaysAgo?: V[]) {
+>(reserves: T[], currentTimestamp?: number) {
   return reserves.map((reserve) => {
-    const reserve30DaysAgo = reserveIndexes30DaysAgo?.find(
-      (res) => res.id === reserve.id
-    )?.paramsHistory?.[0];
-
     const availableLiquidity = normalize(
       reserve.availableLiquidity,
       reserve.decimals
@@ -457,33 +443,13 @@ export function formatReserves<
       availableLiquidity,
       utilizationRate,
       totalDebt: totalDebt.toString(),
-      price: {
-        ...reserve.price,
-        priceInEth: normalize(reserve.price.priceInEth, ETH_DECIMALS),
-      },
+      priceInEth: normalize(reserve.price.priceInEth, ETH_DECIMALS),
       baseLTVasCollateral: normalize(
         reserve.baseLTVasCollateral,
         LTV_PRECISION
       ),
       reserveFactor: normalize(reserve.reserveFactor, LTV_PRECISION),
       variableBorrowRate: normalize(reserve.variableBorrowRate, RAY_DECIMALS),
-      avg30DaysVariableBorrowRate: reserve30DaysAgo
-        ? calculateAverageRate(
-            reserve30DaysAgo.variableBorrowIndex,
-            reserve.variableBorrowIndex,
-            reserve30DaysAgo.timestamp,
-            reserve.lastUpdateTimestamp
-          )
-        : undefined,
-      avg30DaysLiquidityRate: reserve30DaysAgo
-        ? calculateAverageRate(
-            reserve30DaysAgo.liquidityIndex,
-            reserve.liquidityIndex,
-            reserve30DaysAgo.timestamp,
-            reserve.lastUpdateTimestamp
-          )
-        : undefined,
-
       stableBorrowRate: normalize(reserve.stableBorrowRate, RAY_DECIMALS),
       liquidityRate: normalize(reserve.liquidityRate, RAY_DECIMALS),
       liquidityIndex: normalize(reserve.liquidityIndex, RAY_DECIMALS),

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -27,6 +27,7 @@ import {
   ComputedReserveData,
 } from './types';
 import { ETH_DECIMALS, RAY_DECIMALS, USD_DECIMALS } from '../helpers/constants';
+import { Tracing } from 'trace_events';
 
 export function getEthAndUsdBalance(
   balance: BigNumberValue,
@@ -357,7 +358,16 @@ export function formatUserSummaryData(
  * @param currentTimestamp unix timestamp which must be higher than reserve.lastUpdateTimestamp
  */
 export function calculateReserveDebt(
-  reserve: ReserveData,
+  reserve: {
+    totalScaledVariableDebt: string;
+    totalPrincipalStableDebt: string;
+    averageStableRate: string;
+    variableBorrowIndex: string;
+    variableBorrowRate: string;
+    lastUpdateTimestamp: number;
+    stableDebtLastUpdateTimestamp: number;
+    decimals: number;
+  },
   currentTimestamp: number
 ) {
   const totalVariableDebt = normalize(
@@ -385,11 +395,38 @@ export function calculateReserveDebt(
   return { totalVariableDebt, totalStableDebt };
 }
 
-export function formatReserves(
-  reserves: ReserveData[],
-  currentTimestamp?: number,
-  reserveIndexes30DaysAgo?: ReserveRatesData[]
-): ComputedReserveData[] {
+export function formatReserves<
+  T extends {
+    availableLiquidity: string;
+    averageStableRate: string;
+    baseLTVasCollateral: string;
+    decimals: number;
+    id: string;
+    lastUpdateTimestamp: number;
+    liquidityIndex: string;
+    liquidityRate: string;
+    price: {
+      priceInEth: string;
+    };
+    reserveFactor: string;
+    reserveLiquidationBonus: string;
+    reserveLiquidationThreshold: string;
+    stableBorrowRate: string;
+    stableDebtLastUpdateTimestamp: number;
+    totalScaledVariableDebt: string;
+    totalPrincipalStableDebt: string;
+    variableBorrowIndex: string;
+    variableBorrowRate: string;
+  },
+  V extends {
+    id: string;
+    paramsHistory: {
+      variableBorrowIndex: string;
+      liquidityIndex: string;
+      timestamp: number;
+    }[];
+  }
+>(reserves: T[], currentTimestamp?: number, reserveIndexes30DaysAgo?: V[]) {
   return reserves.map((reserve) => {
     const reserve30DaysAgo = reserveIndexes30DaysAgo?.find(
       (res) => res.id === reserve.id

--- a/src/v2/computations-and-formatting.ts
+++ b/src/v2/computations-and-formatting.ts
@@ -12,7 +12,6 @@ import {
   calculateHealthFactorFromBalances,
   getCompoundedBalance,
   getCompoundedStableBalance,
-  calculateAverageRate,
   LTV_PRECISION,
   calculateCompoundedInterest,
   getLinearBalance,
@@ -23,11 +22,8 @@ import {
   ReserveData,
   UserReserveData,
   UserSummaryData,
-  ReserveRatesData,
-  ComputedReserveData,
 } from './types';
 import { ETH_DECIMALS, RAY_DECIMALS, USD_DECIMALS } from '../helpers/constants';
-import { Tracing } from 'trace_events';
 
 export function getEthAndUsdBalance(
   balance: BigNumberValue,
@@ -443,7 +439,7 @@ export function formatReserves<
       availableLiquidity,
       utilizationRate,
       totalDebt: totalDebt.toString(),
-      priceInEth: normalize(reserve.price.priceInEth, ETH_DECIMALS),
+      priceInEth: normalize(reserve.priceInEth, ETH_DECIMALS),
       baseLTVasCollateral: normalize(
         reserve.baseLTVasCollateral,
         LTV_PRECISION


### PR DESCRIPTION
Currently aave-js is super coupled to our graphql types & the aave user interface, but our users aren't necessarily.
This introduces usage problems when data comes from other sources.

In the example of `formatReserves` we expect:
- a full `ReserveData` item, although we only need a very small subset.
- the price to be nested 
- the reference reserve to be an array of reserves containing an array of `paramsHistory` where the first item is expected to contain the `30dagoData`.

I think the 30dago should not be part of that function, the input type should be as narrow as possible and the price should be flat.
This would allow us much easier usage of the function even when data comes from the blockchain or other sources instead of thegraph.

---

Related to #116